### PR TITLE
Skip CI when publishing doc

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -11,7 +11,7 @@ git fetch  # Make sure we are up to date with git remote branches
 git add --all
 git config --global user.name "OpenFisca-Bot"
 git config --global user.email "bot@openfisca.org"
-git diff-index --quiet HEAD || git commit --message="Push from openfisca doc"
+git diff-index --quiet HEAD || git commit --message="[skip ci] Push from openfisca doc"
 git push https://github.com/openfisca/openfisca.org.git gh-pages
 if git status --untracked-files=no ; then
 	echo "There was an issue pushing to openfisca.org"
@@ -23,5 +23,5 @@ git checkout --detach
 git reset --soft origin/doc-html
 git checkout doc-html
 git add --all
-git diff-index --quiet HEAD || git commit --message="Push from openfisca doc"
+git diff-index --quiet HEAD || git commit --message="[skip ci] Push from openfisca doc"
 git push


### PR DESCRIPTION
When trying to publish the doc, builds are not skipped in CircleCI when they should.

Example : https://circleci.com/gh/openfisca/openfisca.org/892

<img width="1341" alt="Capture d’écran 2019-12-27 à 03 38 01" src="https://user-images.githubusercontent.com/329236/71497883-6da63c00-285a-11ea-8e1e-844f822f6ac4.png">

This is harmless but noisy, here a proposed solution.