### PR TITLE
Add reference to "rules as code" in landing

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -1,6 +1,6 @@
 # <i class="fas fa-home"></i> Before you start
 
-[OpenFisca](https://www.openfisca.org) is an open source project that allows you to turn legislation into code.
+[OpenFisca](https://www.openfisca.org) is an open source "rules as code" framework to write machine-consummable legislation.
 
 Describe your tax & benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
 

--- a/source/index.md
+++ b/source/index.md
@@ -1,6 +1,6 @@
 # <i class="fas fa-home"></i> Before you start
 
-[OpenFisca](https://www.openfisca.org) is an open source "rules as code" platform.
+[OpenFisca](https://www.openfisca.org) is an open source platform to write rules as code.
 
 Describe your tax & benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
 

--- a/source/index.md
+++ b/source/index.md
@@ -1,6 +1,6 @@
 # <i class="fas fa-home"></i> Before you start
 
-[OpenFisca](https://www.openfisca.org) is an open source "rules as code" framework to write machine-consummable legislation.
+[OpenFisca](https://www.openfisca.org) is an open source "rules as code" platform.
 
 Describe your tax & benefit system, provide a situation as input (i.e income), ask for a calculation as output (i.e. income tax), and get your results.
 


### PR DESCRIPTION
As "rules as code" becomes the standard theoretical framework within whom OpenFisca is referenced, I think it will help less microsimulation-savvy people to find themselves in the documentation.

Part of https://trello.com/c/M0VU1GTy/18-cross-reference-doc-with-rac