### PR TITLE
Document legislation parameters can be non-numeric

### DIFF
--- a/source/key-concepts/parameters.md
+++ b/source/key-concepts/parameters.md
@@ -2,13 +2,13 @@
 
 A parameter is a numeric property of the legislation which can evolve over time.
 
-Unlike a [variable](./variables.md), a parameter is **not** specific to a specific person or family.
+Unlike a [variable](./variables.md), a parameter is **not** specific to a specific entity (person, household…).
 
 For instance:
 
-* The amount of the *minimum wage*
-* The amount of *family allowance per children*
-* The *marginal tax scale* used to calculate the income tax
+- the amount of the minimum wage;
+- the amount of family allowance per children;
+- the marginal tax scale used to calculate the income tax;
 
 Parameters are used in [formulas](./variables.md#formulas) to calculate variable values.
 

--- a/source/key-concepts/parameters.md
+++ b/source/key-concepts/parameters.md
@@ -14,4 +14,4 @@ For instance:
 
 Parameters are used in [formulas](./variables.md#formulas) to calculate variable values.
 
-[Read more about their implementation in OpenFisca](../coding-the-legislation/legislation_parameters.md)
+[Read more about their implementation in OpenFisca](../coding-the-legislation/legislation_parameters.md).

--- a/source/key-concepts/parameters.md
+++ b/source/key-concepts/parameters.md
@@ -1,6 +1,6 @@
 # Parameters
 
-A parameter is a numeric property of the legislation which can evolve over time.
+A parameter is a property of the legislation that changes over time.
 
 Unlike a [variable](./variables.md), a parameter is **not** specific to a specific entity (person, household…).
 
@@ -9,6 +9,8 @@ For instance:
 - the amount of the minimum wage;
 - the amount of family allowance per children;
 - the marginal tax scale used to calculate the income tax;
+- the maximum age at which a person is entitled to some benefits;
+- the list of regions in which a tax is applicable…
 
 Parameters are used in [formulas](./variables.md#formulas) to calculate variable values.
 


### PR DESCRIPTION
This part of the documentation is already misleading as boolean values are allowed.
This PR updates the description of legislation parameters in the light of https://github.com/openfisca/openfisca-core/pull/982.