### PR TITLE
Use pip legacy resolver on Netlify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install app dependencies
           command: |
             pip install --upgrade pip
-            pip install -r requirements.txt
+            pip install -r requirements.txt --use-deprecated=legacy-resolver
 
       - save_cache:
           key: dependency-cache-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install app dependencies
           command: |
             pip install --upgrade pip
-            pip install -r requirements.txt --use-deprecated=legacy-resolver
+            pip install -r requirements.txt
 
       - save_cache:
           key: dependency-cache-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
 
       - run:
           name: Install app dependencies
-          command: pip install -r requirements.txt
+          command: |
+            pip install --upgrade pip
+            pip install -r requirements.txt --use-deprecated=legacy-resolver
 
       - save_cache:
           key: dependency-cache-{{ checksum "requirements.txt" }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To install dependencies, run:
 
 ```
-pip install -r requirements.txt --use-deprecated=legacy-resolver
+pip install -r requirements.txt
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To install dependencies, run:
 
 ```
-pip install -r requirements.txt
+pip install -r requirements.txt --use-deprecated=legacy-resolver
 ```
 
 ## Build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+# Use pip's legacy dependencies resolver
+# It is expected to become faster >= 21.1.0
+[build.environment]
+  PIP_USE_DEPRECATED = "legacy-resolver"


### PR DESCRIPTION
OpenFisca depends on some heavy to download and to install libraries.

The way pip's new dependency resolver works is to try to download them all and compare compatibilities.

Which times out in Netlify...

This PR tells Netlify to use the legacy resolver for building the [preview apps](https://deploy-preview-235--openfisca-doc.netlify.app/) –to test a pull request changes.