### PR TITLE
Fix some spelling, typography and grammar mistakes

### DIFF
--- a/source/coding-the-legislation/10_basic_example.md
+++ b/source/coding-the-legislation/10_basic_example.md
@@ -28,7 +28,7 @@ All variables have a set of attributes.
 * `value_type` defines the type of the formula output. Possible types are the basic Python types.
 Note however that OpenFisca uses NumPy to [run calculations vectorially](25_vectorial_computing.md),
 so the actual type of data may be slightly different from the built-in Python ones.
-Available types are :
+Available types are:
     - `bool`: boolean
     - `date`: date
     - `Enum`: discrete value (from an enumerable). [See details](20_input_variables.md) in the next section.

--- a/source/coding-the-legislation/20_input_variables.md
+++ b/source/coding-the-legislation/20_input_variables.md
@@ -79,7 +79,7 @@ class housing_occupancy_status(Variable):
 ```
 
 
-You can now use the enum in variable formulas !
+You can now use the enum in variable formulas!
 
 For instance, assuming the enumeration and the formula using it are defined in the same file:
 
@@ -112,7 +112,7 @@ class housing_tax(Variable):
     def formula(household, period, legislation):
         accommodation_size = household('accomodation_size', period)
         housing_occupancy_status = household('housing_occupancy_status', period)
-        HousingOccupancyStatus = housing_occupancy_status.possible_values  # "Import" the enum type. Careful: do not use python imports accross variables files: comparisons would not work !
+        HousingOccupancyStatus = housing_occupancy_status.possible_values  # "Import" the enum type. Careful: do not use python imports accross variables files: comparisons would not work!
         tenant = (housing_occupancy_status == HousingOccupancyStatus.tenant)
         owner = (housing_occupancy_status == HousingOccupancyStatus.owner)
 

--- a/source/coding-the-legislation/35_periods.md
+++ b/source/coding-the-legislation/35_periods.md
@@ -46,7 +46,7 @@ simulation.calculate('housing_allowance', 'month:2019-05-01:1')
 
 With OpenFisca you can calculate variables such as `salary` that can change over time. You can also evaluate the impact of this `salary` on the `income_tax`.
 
-These variables can evolve through time at a diffent periodicity. Here for example, `salary` changes from month to month while the `income_tax` is calculated on a yearly basis.
+These variables can evolve through time at a different periodicity. Here for example, `salary` changes from month to month while the `income_tax` is calculated on a yearly basis.
 
 Therefore, all OpenFisca variables have a `definition_period` attribute:
   - `definition_period = DAY`: The variable may have a different value each day.
@@ -83,7 +83,7 @@ class taxes(Variable):
     definition_period = YEAR
 
     def formula(person, period):  # period is a year because definition_period = YEAR
-        salary_past_year = person('salary', period)  # salary is a montly variable. This will cause an error.
+        salary_past_year = person('salary', period)  # salary is a monthly variable. This will cause an error.
         ...
 ```
 
@@ -170,7 +170,7 @@ By default, when you provide a simulation input, you won't be able to set a vari
 
 For instance, if the `definition_period` of `salary` is `MONTH`, and you input a value for `salary` for `2015` or more than one month, an error will be raised.
 
-It is however possible to define an automatic behaviour to cast yearly inputs into monthy values. To do this, add a `set_input` class attribute to a variable.
+It is however possible to define an automatic behaviour to cast yearly inputs into monthly values. To do this, add a `set_input` class attribute to a variable.
 
 * `set_input = set_input_divide_by_period`: the 12 months are set equal to 1/12th of the input value,
 * `set_input = set_input_dispatch_by_period`: the 12 months are set equal to input value.

--- a/source/coding-the-legislation/legislation_parameters.md
+++ b/source/coding-the-legislation/legislation_parameters.md
@@ -153,7 +153,7 @@ The scales built-in OpenFisca are:
   - Defined as in the previous YAML example, but replacing `rate` by `amount`, and setting `type` to `single_amount` to the parameter's metadata
 
 
-Example: [the french tax scale on income](https://fr.openfisca.org/legislation/impot_revenu.bareme)
+Example: [the French tax scale on income](https://fr.openfisca.org/legislation/impot_revenu.bareme)
 
 
 #### Computing a parameter that depends on a variable (fancy indexing)

--- a/source/coding-the-legislation/legislation_parameters.md
+++ b/source/coding-the-legislation/legislation_parameters.md
@@ -73,7 +73,7 @@ In this file structure:
 
 Names should begin with a lowercase letter and should contain only lowercase letters and the underscore (`_`).
 
-The following keywords are reserved and should not be used as names : `description`, `reference`, `values`, `brackets`.
+The following keywords are reserved and should not be used as names: `description`, `reference`, `values`, `brackets`.
 
 YAML parameter files should not be name `index.yaml`.
 
@@ -233,7 +233,7 @@ def formula(household, period, parameters):
 
 `parameters(period).housing_benefit[zone]` return the parameters for the zone corresponding to the household.
 
-If there are many households in your simulation, this parameter will be **vectorial** : it may have a different value for each household of your entity.
+If there are many households in your simulation, this parameter will be **vectorial**: it may have a different value for each household of your entity.
 
 To be able to use this notation, all the children node of the parameter node `housing_benefit` must be **homogenous**. In the previous example, `housing_benefit.zone_1`, `housing_benefit.zone_2`, `housing_benefit.zone_3` are homogenous, as they have the same subnodes.
 
@@ -285,7 +285,7 @@ And then to get `parameters(period).housing_benefit.amount_by_zone[zone]`
 
 Set-up your python file by importing a `country package` and building the `tax and benefit system`
 
-> Example :
+> Example:
 > ```
 > import openfisca_country_template
 > tax_benefit_system = openfisca_country_template.CountryTaxBenefitSystem()
@@ -294,7 +294,7 @@ Set-up your python file by importing a `country package` and building the `tax a
 ### Access a parameter for all periods
 
 To access a point in the parameter tree, call `tax_benefit_system.parameters`
-> Example :
+> Example:
 > Access the `benefit` branch of the `openfisca-country-template` legislation
 > ```py
 > tax_benefit_system.parameters.benefits

--- a/source/contribute/extensions.md
+++ b/source/contribute/extensions.md
@@ -2,7 +2,7 @@
 
 Extensions allow you to define new variables or parameters for a tax and benefit system, while keeping their code separated from the main country package. They can only _add_ variables and parameters to the tax and benefit system: they cannot _modify_ or _neutralize_ existing ones.
 
-They are for instance used to code local prestations.
+They are for instance used to code local benefits.
 
 > Extensions are sometimes confused with another mechanism: reforms. [Read more about their respective uses](../key-concepts/reforms.md#differences-between-reforms-and-extensions).
 

--- a/source/contribute/guidelines.md
+++ b/source/contribute/guidelines.md
@@ -45,7 +45,7 @@ It is considered a good practice to begin the name of the pull request with a ve
 Before allowing you to merge a PR, the continuous integration server will ensure that:
 
 - The automated tests are passing (they are triggered automatically and result is visible from the Pull Request page).
-- The semantic version number has been updated. Check the [semantic versionning guidelines](semver.md) to know more about how to increment the version number.
+- The semantic version number has been updated. Check the [semantic versioning guidelines](semver.md) to know more about how to increment the version number.
 - The [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md) has been updated. Make sure to briefly summarize your work, and to **mention any non backward-compatible changes**.
 
 #### Web API version number

--- a/source/contribute/index.md
+++ b/source/contribute/index.md
@@ -26,7 +26,7 @@ Thanks for enhancing OpenFisca anyway!
 ## Why contribute to OpenFisca?
 
 OpenFisca is a project being developed under the [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) license.
-The source code is freely available and modifiable. Please refer to the [Publishing results based on OpenFisca](../licence.md) page for a detailed explanation of the implications of this provision.
+The source code is freely available and modifiable. Please refer to the [Publishing results based on OpenFisca](../license.md) page for a detailed explanation of the implications of this provision.
 
 We encourage users to send their comments and suggestions for improvement,
 and to report any inaccuracy or error they might have found.

--- a/source/contribute/semver.md
+++ b/source/contribute/semver.md
@@ -1,9 +1,9 @@
-Semantic versionning guidelines
+Semantic versioning guidelines
 ===============================
 
 Before merging your contribution to an OpenFisca package, you are required to increment the version of this package.
 
-The [semantic versionning convention](http://semver.org/), applied here, requires you to:
+The [semantic versioning convention](http://semver.org/), applied here, requires you to:
 
 
 >Given a version number MAJOR.MINOR.PATCH, increment the:

--- a/source/contribute/semver.md
+++ b/source/contribute/semver.md
@@ -14,7 +14,7 @@ The [semantic versioning convention](http://semver.org/), applied here, requires
 
 >**PATCH** version when you make backwards-compatible bug fixes.
 
-It is thus crucial to determine whether your changes are **backwards-compatible**. If, during a hackathon, a contributor has written a reform to OpenFisca, would this reform still work after adding your changes ?
+It is thus crucial to determine whether your changes are **backwards-compatible**. If, during a hackathon, a contributor has written a reform to OpenFisca, would this reform still work after adding your changes?
 
 Examples in OpenFisca context
 -----------------------------

--- a/source/index.md
+++ b/source/index.md
@@ -44,7 +44,7 @@ There are two ways to calculate the effect of the rules modelled in a country pa
 
 The output of this simulation will be either Python objects or JSON. Many other libraries will then help you represent these results graphically ([plot.ly](https://plot.ly) for instance will get you those nice charts you’ve seen elsewhere).
 
-Please make sure you read our [license](licence.md) before publishing results based on OpenFisca.
+Please make sure you read our [license](license.md) before publishing results based on OpenFisca.
 
 ## Things OpenFisca won’t do for you
 

--- a/source/installation/index.md
+++ b/source/installation/index.md
@@ -20,4 +20,4 @@ The purpose of this section is to bring together the clever solutions the commun
 - [How to work on OpenFisca on a Windows without being administrator](./windows-no-admin.md)
 - [How to test your changes on "ready to use" situations](./test_situations.md)
 
-> You're welcome to share your tips on how to solve technical issues! Please update [this section](https://github.com/openfisca/openfisca-doc/edit/master/recipes.md) (in english) or this [wiki FAQ](https://github.com/openfisca/tutorial/wiki) in your preferred language.
+> You're welcome to share your tips on how to solve technical issues! Please update [this section](https://github.com/openfisca/openfisca-doc/edit/master/recipes.md) (in English) or this [wiki FAQ](https://github.com/openfisca/tutorial/wiki) in your preferred language.

--- a/source/key-concepts/reforms.md
+++ b/source/key-concepts/reforms.md
@@ -16,4 +16,4 @@ To use reforms or code your own ones, check the [reform documentation](../coding
 Reforms are sometimes confused with another mechanism: [extensions](../contribute/extensions.md). These two mechanisms do not have the same purpose:
 
 - Use a reform if you want to modify a tax and benefit system in order to study the impact of a legislation change.
-- Use an extension if you want to write formulas that are based on a main tax and benefit system, while keeping their code separated from the main country package (e.g. for local prestations).
+- Use an extension if you want to write formulas that are based on a main tax and benefit system, while keeping their code separated from the main country package (e.g. for local benefits).

--- a/source/license.md
+++ b/source/license.md
@@ -1,4 +1,4 @@
-# <i class="fab fa-creative-commons"></i> Licence
+# <i class="fab fa-creative-commons"></i> License
 
 OpenFisca is free software made available under the [AGPL license](https://choosealicense.com/licenses/agpl-3.0/). This means that you are free to use, install and modify it, and that you have to contribute your changes back to the community. This is the only way a contributive digital common can be sustainable, so we are very happy that you take part in this shared effort!
 

--- a/source/summary.rst
+++ b/source/summary.rst
@@ -13,5 +13,5 @@
 
    find-help
    contribute/index
-   licence
+   license
    manifest-history


### PR DESCRIPTION
This changeset aggregates many typo fixes and corrections of English written by French native speakers spotted along the way of previous pull requests. Each mistake that was spotted was generalised by search-and-replace. However, this changeset does not constitute a thorough proofreading of the documentation.

This changeset has a backwards-incompatible change: the renaming of the `licence` page to `license`, breaking URLs.