### PR TITLE
fix(entities): fix broken core documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 .python-version
 .venv
 build/*

--- a/source/conf.py
+++ b/source/conf.py
@@ -69,9 +69,13 @@ autodoc_default_options = {
     'ignore-module-all': True
 }
 
+napoleon_custom_sections = [('Returns', 'params_style')]
+
+
 def missing_reference(app, env, node, contnode):
     if node['reftype'] == 'class' and node['reftarget'].startswith('nptyping'):
         return contnode
+
 
 def setup(app):
     app.add_config_value('recommonmark_config', {

--- a/source/openfisca-python-api/commons.rst
+++ b/source/openfisca-python-api/commons.rst
@@ -4,4 +4,4 @@ Commons
 
 .. automodule:: openfisca_core.commons
     :members:
-    :special-members: __call__
+    :imported-members:

--- a/source/openfisca-python-api/entities.rst
+++ b/source/openfisca-python-api/entities.rst
@@ -2,17 +2,7 @@
 Entities
 ========
 
-.. module:: openfisca_core.entities
-
-.. autoclass:: Role
-    :noindex:
+.. automodule:: openfisca_core.entities
     :members:
-
-.. autoclass:: Entity
-    :members:
-
-.. autoclass:: GroupEntity
-    :members:
-
-.. automodule:: openfisca_core.entities.helpers
-    :members:
+    :imported-members:
+    :inherited-members:


### PR DESCRIPTION
Depends on openfisca/openfisca-core#1253
Depends on openfisca/openfisca-core#1256

We're using the `autodoc` extension to help `sphinx` update the documentation dynamically. However, when there are two elements with the same name in the global space, like :class:`Variable`, `autodoc` won't know how to decide which one to choose. This changeset fixes the corresponding warnings by updating the faulty doc in core.