### PR TITLE
docs: add docs to data storage & enums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ install:
 	@pip install --upgrade pip
 	@pip install -r requirements.txt --use-deprecated=legacy-resolver
 
-test: lint test-build
+test:
+	@${MAKE} lint
+	@${MAKE} test-build
 
 test-build:
 	@${MAKE} dummy SPHINXOPTS="--quiet --fail-on-warning"

--- a/source/conf.py
+++ b/source/conf.py
@@ -69,7 +69,10 @@ autodoc_default_options = {
     'ignore-module-all': True
 }
 
-napoleon_custom_sections = [('Returns', 'params_style')]
+napoleon_custom_sections = [
+    ('Raises', 'params_style'),
+    ('Returns', 'params_style'),
+]
 
 
 def missing_reference(app, env, node, contnode):

--- a/source/openfisca-python-api/data_storage.rst
+++ b/source/openfisca-python-api/data_storage.rst
@@ -1,0 +1,8 @@
+============
+Data Storage
+============
+
+.. automodule:: openfisca_core.data_storage
+    :members:
+    :imported-members:
+    :private-members: _decode_file

--- a/source/openfisca-python-api/enum_array.rst
+++ b/source/openfisca-python-api/enum_array.rst
@@ -2,13 +2,7 @@
 Enum & EnumArray
 ================
 
-.. module:: openfisca_core.indexed_enums
-
-.. autoclass:: Enum
-  :members:
-
-.. autoclass:: EnumArray
-  :members:
-
-.. automodule:: openfisca_core.indexed_enums.config
+.. automodule:: openfisca_core.indexed_enums
     :members:
+    :imported-members:
+    :special-members: __eq__, __ne__, __new__, __array_finalize__

--- a/source/openfisca-python-api/index.md
+++ b/source/openfisca-python-api/index.md
@@ -4,6 +4,7 @@ Modules:
 
 ```{toctree}
 commons
+data_storage
 tax-benefit-system
 variables
 parameters


### PR DESCRIPTION
Depends on https://github.com/openfisca/openfisca-core/pull/1263
Depends on https://github.com/openfisca/openfisca-core/pull/1272

#### Documentation

- Add documentation to the `data_storage` module
- Add documentation to the `indexed_enums` module