### PR TITLE
Remove Twitter from contact possibilities

### DIFF
--- a/source/find-help.md
+++ b/source/find-help.md
@@ -30,5 +30,4 @@ _For example- `france-ext-paris`_.
 Contact the OpenFisca maintainers through:
 
 - [GitHub](./contribute/guidelines.md#opening-issues) if you have any technical issues.
-- Twitter [@OpenFisca](https://twitter.com/OpenFisca) for general inquiries and feedback.
 - [Email](mailto:contact@openfisca.org) for collaboration opportunities.


### PR DESCRIPTION
We don't use Musk property, that account has been deleted.

Related to https://github.com/openfisca/openfisca.org/pull/190